### PR TITLE
Header links

### DIFF
--- a/src/SFA.DAS.Campaign.Web/Views/Apprentice/Application.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Apprentice/Application.cshtml
@@ -1,4 +1,6 @@
-﻿
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
 @{
     ViewBag.Title = "Application";
     ViewBag.MetaTitle = "Application";
@@ -15,10 +17,11 @@
 
 <p>
     If you haven't found your ideal apprenticeship yet, you can <a href="https://www.findapprenticeship.service.gov.uk/apprenticeshipsearch" target="_blank" rel="external" id="link-faa">
-        search for the latest apprenticeship vacancies</a> by job title or employer, or just browse to see what’s available in your area. 
+        search for the latest apprenticeship vacancies
+    </a> by job title or employer, or just browse to see what’s available in your area.
 </p>
 <p>
-You can then manage your applications and even get alerts about new apprenticeships. 
+    You can then manage your applications and even get alerts about new apprenticeships.
 </p>
 
 <h3 class="heading-s">Apply for the job and send the application to the employer</h3>
@@ -71,7 +74,7 @@ You can then manage your applications and even get alerts about new apprenticesh
 
 <ul class="pagination pagination--apprentice">
     <li class="pagination__list-item">
-        <a  href="https://www.findapprenticeship.service.gov.uk/apprenticeshipsearch" id="link-pagination-faa" class="pagination__link pagination__link--previous" rel="external" target="_blank">
+        <a href="https://www.findapprenticeship.service.gov.uk/apprenticeshipsearch" id="link-pagination-faa" class="pagination__link pagination__link--previous" rel="external" target="_blank">
             Find an apprenticeship
         </a>
     </li>

--- a/src/SFA.DAS.Campaign.Web/Views/Apprentice/AssessmentAndQualification.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Apprentice/AssessmentAndQualification.cshtml
@@ -1,4 +1,7 @@
-﻿@{
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
+@{
     ViewBag.Title = "Assessment and certification";
     ViewBag.PageID = "apprentice-assessment-and-certification";
     ViewBag.Section = "apprentice";
@@ -7,35 +10,36 @@
     Layout = "_LayoutContentSidebar";
     ViewBag.PageNavIndex = 6;
 }
-<h2 class="heading-m">Get Assessed and get your certificate</h2>
+<h2 class="heading-m" id="h1">Get assessed and get your certificate</h2>
 <p>
-    You will be assessed at some stage during your apprenticeship, to make sure you 
-    have achieved the knowledge, skills and behaviours required. 
-    Increasingly, many apprenticeships now include an end-point assessment, which will 
-    test you at the end of the apprenticeship to make sure you are fully competent 
+    You will be assessed at some stage during your apprenticeship, to make sure you
+    have achieved the knowledge, skills and behaviours required.
+    Increasingly, many apprenticeships now include an end-point assessment, which will
+    test you at the end of the apprenticeship to make sure you are fully competent
     in your apprenticeship occupation.
 </p>
 <p>
-    Your employer and training provider should give you 
-    plenty of guidance as to what’s expected, and when your assessment 
-    will happen. 
+    Your employer and training provider should give you
+    plenty of guidance as to what’s expected, and when your assessment
+    will happen.
 </p>
 
 
-<h2 class="heading-m">Complete your apprenticeship</h2>
+<h2 class="heading-m" id="h2">Complete your apprenticeship</h2>
 <p>
-    Pass the assessment, finish your apprenticeship, 
-    enjoy the moment (then jump around, scream, shout, post something on social media). 
+    Pass the assessment, finish your apprenticeship,
+    enjoy the moment (then jump around, scream, shout, post something on social media).
     You’ve done it, you did it, you’ve earned this!
 </p>
 <p>
     So where next?
 </p>
 <p>
-    Just like your apprenticeship, the answer’s up to you. You’ve 
-    got a whole new set of skills, an apprenticeship that’ll impress 
-    employers, and really useful experiences that 
-    show that you can make the step up from apprentice to, well, wherever you want to go.</p>
+    Just like your apprenticeship, the answer’s up to you. You’ve
+    got a whole new set of skills, an apprenticeship that’ll impress
+    employers, and really useful experiences that
+    show that you can make the step up from apprentice to, well, wherever you want to go.
+</p>
 
 <partial name="./components/Cta/_Contact-phoneNumber-apprentice" />
 
@@ -43,13 +47,23 @@
     <li class="pagination__list-item">
         <a class="pagination__link pagination__link--previous" asp-controller="Apprentice" asp-action="YourApprenticeship" id="link-pagination-apprentice-5"> Your apprenticeship </a>
     </li>
-
 </ul>
 
-@section pageFooter 
-{
+@{
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">Get assessed and get your certificate</a> </li>
+        <li><a href="#h2" class="hero__link">Complete your apprenticeship</a> </li>
+    </ul>);
+}
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Apprentice, content = HeroHeadingContent() })
+}
+
+@section pageFooter
+    {
     <div class="grid-column">
         <partial name="./Components/Cta/_find-an-apprenticeship" />
-   
+
     </div>
 }

--- a/src/SFA.DAS.Campaign.Web/Views/Apprentice/Interview.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Apprentice/Interview.cshtml
@@ -1,4 +1,7 @@
-﻿@{
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
+@{
     ViewBag.Title = "Interview";
     ViewBag.MetaTitle = "Interview";
     ViewBag.PageID = "apprentice-interview";
@@ -8,7 +11,7 @@
     ViewBag.PageNavIndex = 4;
 }
 
-<h2 class="heading-m">The Interview Process</h2>
+<h2 class="heading-m" id="h1">The Interview Process</h2>
 
 <p>
     Everyone goes through the interview process - at some stage of their working life.  When you apply for new jobs,
@@ -45,7 +48,7 @@
 
 <p>If you've not done an interview before, the following tips should help you through the whole process:</p>
 
-<h2 class="heading-m">Before Your Interview</h2>
+<h2 class="heading-m" id="h2">Before Your Interview</h2>
 
 <h3 class="heading-s">Check where and when</h3>
 <p>
@@ -69,7 +72,7 @@
 </p>
 
 
-<h2 class="heading-m">Day of the interview</h2>
+<h2 class="heading-m" id="h3">Day of the interview</h2>
 
 <h3 class="heading-s">What to wear</h3>
 <p>
@@ -116,11 +119,22 @@
     </li>
 </ul>
 
+@{
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">The interview process</a> </li>
+        <li><a href="#h2" class="hero__link">Before your interview</a> </li>
+        <li><a href="#h3" class="hero__link">Day of the interview</a> </li>
+    </ul>);
+}
 
-@section pageFooter 
-{
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Apprentice, content = HeroHeadingContent() })
+}
+
+@section pageFooter
+    {
     <div class="grid-column">
         <partial name="./Components/Cta/_find-an-apprenticeship" />
-   
+
     </div>
 }

--- a/src/SFA.DAS.Campaign.Web/Views/Apprentice/WhatAreTheBenefitsToMe.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Apprentice/WhatAreTheBenefitsToMe.cshtml
@@ -1,5 +1,6 @@
-﻿@model object
-
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
 @{
     ViewBag.Title = "What are the benefits for me?";
     ViewBag.MetaTitle = "What are the benefits for me? ";
@@ -9,13 +10,11 @@
     Layout = "_LayoutContentSidebar";
     ViewBag.PageNavIndex = 2;
 }
-<h2 class="heading-m">What are my future prospects once I’ve successfully finished my apprenticeship?</h2>
+<h2 class="heading-m" id="h1">What are my future prospects once I’ve successfully finished my apprenticeship?</h2>
 <p>
     Once you’ve successfully finished, you have plenty of choices. You could apply for another apprenticeship or
     find a career that uses your new skills.
 </p>
-
-
 <p>Some of the top reasons for becoming an apprentice:</p>
 <ul class="list list--bullet list--bullet-apprentice">
     <li>earn while you learn and get paid a competitive salary</li>
@@ -26,8 +25,7 @@
     <li>get a boost to your future earnings potential</li>
     <li>develop the skills you need for a range of exciting jobs or careers, no matter your age or background</li>
 </ul>
-
-<h2 class="heading-m">How much can you earn?</h2>
+<h2 class="heading-m" id="h2">How much can you earn?</h2>
 <p>
     Your salary will depend upon the industry, location and type of apprenticeship you choose.
 </p>
@@ -40,7 +38,7 @@
     you are entitled to the national <a href="https://www.gov.uk/national-minimum-wage-rates" target="_blank" rel="external" id="link-min-wage">minimum wage</a> for your age.
 </p>
 
-<h2 class="heading-m">What will my apprenticeship cost me?</h2>
+<h2 class="heading-m" id="h3">What will my apprenticeship cost me?</h2>
 <p>
     When you become an apprentice, you’ll need to cover the cost of your day-to-day expenses,
     such as lunch and travel.
@@ -53,11 +51,22 @@
 <partial name="./components/Cta/_Contact-phoneNumber-apprentice" />
 <hr class="section-break" />
 
+@{
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+    <li><a href="#h1" class="hero__link">What are my future prospects once I’ve successfully finished my apprenticeship?</a> </li>
+    <li><a href="#h2" class="hero__link">How much can you earn?</a> </li>
+    <li><a href="#h2" class="hero__link">What will my apprenticeship cost me?</a> </li>
+</ul>);
+}
 
-@section pageFooter 
-{
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Apprentice, content = HeroHeadingContent() })
+}
+
+@section pageFooter
+    {
     <div class="grid-column">
         <partial name="./Components/Cta/_find-an-apprenticeship" />
-   
+
     </div>
 }

--- a/src/SFA.DAS.Campaign.Web/Views/Apprentice/WhatIsAnApprenticeship.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Apprentice/WhatIsAnApprenticeship.cshtml
@@ -1,5 +1,7 @@
-﻿@model object
-
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
+@model object
 @{
     ViewBag.Title = "What is an apprenticeship?";
     ViewBag.PageID = "apprenticeship-whats-an-apprenticeship";
@@ -14,7 +16,8 @@
     It’s a real job, with hands-on experience, a salary
     and the chance to train while you work. You get the same as
     other employees – a contract of employment and holiday leave.
-</p><p>
+</p>
+<p>
     If you’re 16 or over, you can become an apprentice as long as
     you spend at least 50% of your working hours in England - for the duration of the
     apprenticeship and you are not in full-time education.
@@ -24,7 +27,7 @@
     <a href="https://www.apprenticeships.scot/" target="_blank" rel="external" id="link-scotland">Scotland</a>,
     <a href="https://beta.gov.wales/apprenticeships-skills-and-training" target="_blank" rel="external" id="link-wales">Wales</a>, or <a href="https://www.nidirect.gov.uk/campaigns/apprenticeships" target="_blank" rel="external" id="link-northern-ireland">Northern Ireland</a>, check out your apprenticeship options.
 </p>
-</p><p>
+<p>
     When you're an apprentice:
 </p>
 <ul class="list list--bullet list--bullet-apprentice">
@@ -61,7 +64,7 @@
 
 
 </p>
-<h2 class="heading-m">What are the different types of apprenticeships?</h2>
+<h2 class="heading-m" id="h1">What are the different types of apprenticeships?</h2>
 
 <p>
     There are hundreds of different apprenticeships to choose from.
@@ -92,10 +95,20 @@
     </li>
 </ul>
 
-@section pageFooter 
-{
-<div class="grid-column">
-    <partial name="./Components/Cta/_find-an-apprenticeship" />
-   
-</div>
+@{
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">What are the different types of apprenticeships?</a> </li>
+    </ul>);
+}
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Apprentice, content = HeroHeadingContent() })
+}
+
+@section pageFooter
+    {
+    <div class="grid-column">
+        <partial name="./Components/Cta/_find-an-apprenticeship" />
+
+    </div>
 }

--- a/src/SFA.DAS.Campaign.Web/Views/Apprentice/YourApprenticeship.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Apprentice/YourApprenticeship.cshtml
@@ -1,4 +1,7 @@
-﻿@{
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
+@{
     ViewBag.Title = "Your apprenticeship";
     ViewBag.MetaTitle = "Your apprenticeship";
     ViewBag.PageID = "apprentice-your-apprenticeship";
@@ -7,7 +10,7 @@
     Layout = "_LayoutContentSidebar";
     ViewBag.PageNavIndex = 5;
 }
-<h2 class="heading-m">What to bring, and other useful info</h2>
+<h2 class="heading-m" id="h1">What to bring, and other useful info</h2>
 <p>
     Your employer will be in touch beforehand to let you know your working hours,
     and when they’d like you to start on your first day. If however, you already work at the place where you're
@@ -41,7 +44,7 @@
 
 
 
-<h2 class="heading-m">Meet your new team</h2>
+<h2 class="heading-m" id="h2">Meet your new team</h2>
 
 <p>
     When you start your apprenticeship, you’ll meet the people you'll be working with. They will show
@@ -49,7 +52,7 @@
 
 </p>
 
-<h2 class="heading-m">What comes after my apprenticeship?</h2>
+<h2 class="heading-m" id="h3">What comes after my apprenticeship?</h2>
 <p>
     Apprenticeships are designed to make you ‘job-ready’ in the role you're training for.
     Once your apprenticeship is up and running, and you’re gaining more experience and learning new skills,
@@ -71,10 +74,24 @@
     </li>
 </ul>
 
-@section pageFooter 
-{
+@{
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">What to bring, and other useful info</a> </li>
+        <li><a href="#h2" class="hero__link">Meet your new team</a> </li>
+        <li><a href="#h3" class="hero__link">What comes after my apprenticeship?</a> </li>
+    </ul>);
+}
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Apprentice, content = HeroHeadingContent() })
+}
+
+
+
+@section pageFooter
+    {
     <div class="grid-column">
         <partial name="./Components/Cta/_find-an-apprenticeship" />
-   
+
     </div>
 }

--- a/src/SFA.DAS.Campaign.Web/Views/Employer/AssessmentAndQualification.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Employer/AssessmentAndQualification.cshtml
@@ -1,4 +1,8 @@
-﻿@{
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
+@model object
+@{
     ViewBag.Title = "Assessment and certification";
     ViewBag.MetaTitle = "Assessment and certification";
     ViewBag.PageID = "employer-assessment-certification";
@@ -7,28 +11,30 @@
     ViewBag.PageNavIndex = 6;
 }
 
-<h2 class="heading-m">Assessment</h2>
+<h2 class="heading-m" id="h1">Assessment</h2>
 <p>
-    Once the apprenticeship training is completed, an independent assessment will take place, this is 
-    called an 'end-point assessment'.  The assessment is the apprentice’s opportunity to demonstrate that they 
-    are genuinely competent in their occupation at the end of their training. 
-    </p><p>
-    It also gives the apprentice the opportunity to demonstrate what they've learnt 
-    throughout the apprenticeship. (This assessment only applies for apprenticeship 
+    Once the apprenticeship training is completed, an independent assessment will take place, this is
+    called an 'end-point assessment'.  The assessment is the apprentice’s opportunity to demonstrate that they
+    are genuinely competent in their occupation at the end of their training.
+</p><p>
+    It also gives the apprentice the opportunity to demonstrate what they've learnt
+    throughout the apprenticeship. (This assessment only applies for apprenticeship
     standards and not for frameworks).
 </p>
-<p>Details of what is in an end-point assessment is set out in the assessment plan. 
-    This will include an assessment of the apprentice's: </p>
+<p>
+    Details of what is in an end-point assessment is set out in the assessment plan.
+    This will include an assessment of the apprentice's:
+</p>
 <ul class="list list--bullet list--bullet-employer">
     <li>knowledge</li>
     <li>skills</li>
     <li>behaviours</li>
 </ul>
 <p>
-    Your apprentice can't achieve an apprenticeship standard without 
+    Your apprentice can't achieve an apprenticeship standard without
     satisfying all the requirements listed in the apprenticeship standard, including the end-point assessment.
 </p>
-<h2 class="heading-m">
+<h2 class="heading-m" id="h2">
     Where to find an end-point assessment organisation
 </h2>
 <p>You must select an organisation to deliver the end-point assessment from the <a href="https://www.gov.uk/government/publications/using-the-register-of-apprentice-assessment-organisations" target="_blank" rel="external" id="link-roepao">register of end-point assessment organisations</a> and agree to a price with this organisation for the end-point assessment.</p>
@@ -38,13 +44,13 @@
 </p>
 <p>
     The training provider must contract with the end-point assessment
-    organisation on your behalf and have a written agreement in place to make payment to them for 
+    organisation on your behalf and have a written agreement in place to make payment to them for
     conducting the end-point assessment.
 </p>
 <h3 class="heading-s">End-point assessment cost</h3>
 <p>We expect that the cost of the end-point assessment should not usually exceed 20% of the funding band maximum.</p>
 <p>This cost is included in the overall cost agreed with the training provider for the apprenticeship.</p>
-<h2 class="heading-m">
+<h2 class="heading-m" id="h3">
     Certification
 </h2>
 <p>
@@ -59,6 +65,19 @@
 <ul class="pagination pagination--employer">
     <li class="pagination__list-item"><a class="pagination__link pagination__link--previous" asp-controller="Employer" asp-action="PreparingAndMonitoring" id="link-pagination-employer-5"> Preparing and monitoring</a></li>
 </ul>
+
+@{
+
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">Assessment </a> </li>
+        <li><a href="#h2" class="hero__link">Where to find an end-point assessment organisation </a> </li>
+        <li><a href="#h3" class="hero__link">Certification </a> </li>
+    </ul>);
+}
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Employer, content = HeroHeadingContent() })
+}
 
 @section Resources {
     <partial name="./Components/Resources/_employer" />

--- a/src/SFA.DAS.Campaign.Web/Views/Employer/Benefits.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Employer/Benefits.cshtml
@@ -1,5 +1,7 @@
+@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
 @model object
-
 @{
     ViewBag.Title = "Benefits to your organisation";
     ViewBag.MetaTitle = "Benefits to your organisation";
@@ -19,7 +21,7 @@
 
 <p>As an employer, you can get additional help with funding an apprentice from the government.</p>
 
-<h2 class="heading-m">The benefits to your organisation</h2>
+<h2 class="heading-m" id="h1">The benefits to your organisation</h2>
 <p>Hiring an apprentice is a productive and effective way for any organisation to grow talent and develop a motivated, skilled and qualified workforce.</p>
 
 <p>Employers who have an established apprenticeship programme reported that productivity in their workplace had improved by 76% whilst 75% reported that apprenticeships improved the quality of their product or service. </p>
@@ -30,9 +32,20 @@
     <li>thousands of organisations are employing apprentices now</li>
     <li>90% of apprentices stay on in their place of work after completing an apprenticeship</li>
     <li>there's a wide selection of apprenticeships available, covering lots of different job roles within a organisation</li>
-   <li>you can adapt the training your apprentice receives according to the needs of your organisation</li>
-   <li>an apprenticeship allows you to diversify and freshen up your workforce</li>
-   <li>you can employ an apprentice who's 16 up to any age and from any background</li>
+    <li>you can adapt the training your apprentice receives according to the needs of your organisation</li>
+    <li>an apprenticeship allows you to diversify and freshen up your workforce</li>
+    <li>you can employ an apprentice who's 16 up to any age and from any background</li>
 </ul>
 
 <partial name="./components/Cta/_Contact-phoneNumber" />
+
+@{
+
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">The benefits to your organisation </a> </li>
+    </ul>);
+}
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Employer, content = HeroHeadingContent() })
+}

--- a/src/SFA.DAS.Campaign.Web/Views/Employer/ChooseATrainingProvider.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Employer/ChooseATrainingProvider.cshtml
@@ -1,5 +1,7 @@
-﻿@model object
-
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
+@model object
 @{
     ViewBag.Title = "Choose a training provider";
     ViewBag.MetaTitle = "Choose a training provider";
@@ -11,15 +13,16 @@
 }
 
 <p>
-You will need to choose a training provider to train your apprentice.
+    You will need to choose a training provider to train your apprentice.
 </p>
 <p>
     <a href="https://findapprenticeshiptraining.sfa.bis.gov.uk/" target="_blank" rel="external" id="link-fat">Find apprenticeship training</a> will help
     you search for one by location, job role or keyword.
 </p>
 
-<p>Your training provider can provide you with as much help and support as you need when you take on an apprentice.
-     
+<p>
+    Your training provider can provide you with as much help and support as you need when you take on an apprentice.
+
 </p>
 <p>
     Your training provider may also be able to help with:
@@ -32,9 +35,9 @@ You will need to choose a training provider to train your apprentice.
     <li>working with you to make sure your apprentice is learning the relevant skills</li>
 </ul>
 
-<h2 class="heading-m">Misunderstandings and myths</h2>
+<h2 class="heading-m" id="h1">Misunderstandings and myths</h2>
 <p>
-    There are some misunderstandings and myths about what you can and can't do when working with a training provider.  
+    There are some misunderstandings and myths about what you can and can't do when working with a training provider.
     Here are a couple of examples:
 </p>
 <ul class="list list--bullet list--bullet-employer">
@@ -53,6 +56,16 @@ You will need to choose a training provider to train your apprentice.
     <li class="pagination__list-item"><a class="pagination__link pagination__link--next" href="/employer/hire-an-apprentice" id="link-pagination-employer-4"> Hire an apprentice</a> </li>
 </ul>
 
+@{
+
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">Misunderstandings and myths </a> </li>
+    </ul>);
+}
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Employer, content = HeroHeadingContent() })
+}
 
 @section Resources {
     <partial name="./Components/Resources/_employer" />

--- a/src/SFA.DAS.Campaign.Web/Views/Employer/HireAnApprentice.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Employer/HireAnApprentice.cshtml
@@ -1,5 +1,7 @@
-﻿@model object
-
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
+@model object
 @{
     ViewBag.Title = "Hire an apprentice";
     ViewBag.MetaTitle = "Hire an apprentice";
@@ -9,10 +11,10 @@
     ViewBag.PageNavIndex = 4;
 }
 
-<h2 class="heading-m">Finding the right apprentice for you</h2>
+<h2 class="heading-m" id="h1">Finding the right apprentice for you</h2>
 
 <p>
-    When you've decided to hire an apprentice you need to think about the right person for you and the benefits 
+    When you've decided to hire an apprentice you need to think about the right person for you and the benefits
     they can bring to your organisation.
 </p>
 
@@ -40,7 +42,7 @@
     <li>participate in shows, such as 'WorldSkills UK Live'</li>
     <li>invite potential apprentices to your organisation for a day, to get a feel for how you work</li>
 </ul>
-<h2 class="heading-m">How to ask the right questions at interview</h2>
+<h2 class="heading-m" id="h2">How to ask the right questions at interview</h2>
 <p>
     Take time to think about what you really need to know and how you’ll
     tease out the best from the interviewee.  You want to find out if the candidate is right for your organisation.
@@ -67,6 +69,17 @@
     <li class="pagination__list-item"><a class="pagination__link pagination__link--next" asp-controller="Employer" asp-action="PreparingAndMonitoring" id="link-pagination-employer-5"> Preparing and monitoring</a></li>
 </ul>
 
+@{
+
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">Finding the right apprentice for you </a> </li>
+        <li><a href="#h2" class="hero__link">How to ask the right questions at interview </a> </li>
+    </ul>);
+}
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Employer, content = HeroHeadingContent() })
+}
 
 @section Resources {
     <partial name="./Components/Resources/_employer" />

--- a/src/SFA.DAS.Campaign.Web/Views/Employer/HowMuchIsItGoingToCost.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Employer/HowMuchIsItGoingToCost.cshtml
@@ -202,8 +202,6 @@ to the training provider.
         <li><a href="#NoLevy" class="hero__link">If you don’t need to pay the apprenticeship levy</a> </li>
         <li><a href="#AdditionalPayments" class="hero__link">Additional payments from the government</a> </li>
     </ul>);
-
-
 }
 
 @section HeroHeading {

--- a/src/SFA.DAS.Campaign.Web/Views/Employer/HowMuchIsItGoingToCost.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Employer/HowMuchIsItGoingToCost.cshtml
@@ -10,7 +10,7 @@
     Layout = "_LayoutContentSidebar";
 }
 
-<h2 class="heading-m">How much will it cost me?</h2>
+<h2 class="heading-m" id="h1">How much will it cost me?</h2>
 <p>
     You can get help from the government to pay for apprenticeship training and assessment.
     The amount you get depends on whether you pay the apprenticeship levy or not.
@@ -26,7 +26,7 @@
     <li><a href="https://beta.gov.wales/apprenticeships-skills-and-training" target="_blank" rel="external" id="link-wales">Wales</a></li>
     <li><a href="https://www.nidirect.gov.uk/campaigns/apprenticeships" target="_blank" rel="external" id="link-northern-ireland">Northern Ireland</a></li>
 </ul>
-<h2 class="heading-m">If you don't need to pay the apprenticeship levy</h2>
+<h2 class="heading-m" id="h2">If you don't need to pay the apprenticeship levy</h2>
 <p>
 As an employer who doesn’t pay the apprenticeship levy, you will need to pay the training 
 provider directly for training your apprentices.
@@ -37,7 +37,7 @@ will pay the rest (90%) up to the <a href="https://www.gov.uk/government/publica
 to the training provider.
 </p>
 
-<h2 class="heading-m">Additional payments from the government</h2>
+<h2 class="heading-m" id="h3">Additional payments from the government</h2>
 
 <h3 class="heading-s">Extra support for small employers</h3>
 <p>
@@ -198,10 +198,10 @@ to the training provider.
 @{
 
     IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
-        <li><a href="#Cost" class="hero__link">How much will it cost me</a> </li>
-        <li><a href="#NoLevy" class="hero__link">If you don’t need to pay the apprenticeship levy</a> </li>
-        <li><a href="#AdditionalPayments" class="hero__link">Additional payments from the government</a> </li>
-    </ul>);
+    <li><a href="#h1" class="hero__link">How much will it cost me? </a> </li>
+    <li><a href="#h2" class="hero__link">If you don't need to pay the apprenticeship levy </a> </li>
+    <li><a href="#h3" class="hero__link">Additional payments from the government </a> </li>
+</ul>);
 }
 
 @section HeroHeading {

--- a/src/SFA.DAS.Campaign.Web/Views/Employer/PreparingAndMonitoring.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Employer/PreparingAndMonitoring.cshtml
@@ -1,5 +1,7 @@
-﻿@model object
-
+﻿@using Microsoft.AspNetCore.Html
+@using SFA.DAS.Campaign.Web.Constants
+@using SFA.DAS.Campaign.Web.ViewComponents.Modal
+@model object
 @{
     ViewBag.Title = "Preparing and monitoring";
     ViewBag.MetaTitle = "Preparing and monitoring";
@@ -20,7 +22,7 @@
     much help as the school leaver, but they may still be nervous and unsure of what’s expected of them.
 </p>
 
-<h2 class="heading-m">Preparing</h2>
+<h2 class="heading-m" id="h1">Preparing</h2>
 <p>
     Before an apprentice starts you should consider sending them a
     starter pack so they know what to expect from their first day.
@@ -39,7 +41,7 @@
 </ul>
 
 
-<h2 class="heading-m">Monitoring</h2>
+<h2 class="heading-m" id="h2">Monitoring</h2>
 
 <p>
     It's important as an employer to support your new apprentice and keep in regular contact with them.
@@ -58,6 +60,17 @@
     <li class="pagination__list-item"><a class="pagination__link pagination__link--next" asp-controller="Employer" asp-action="AssessmentAndQualification" id="link-pagination-employer-6"> Assessment and certification</a></li>
 </ul>
 
+@{
+
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">Preparing </a> </li>
+        <li><a href="#h2" class="hero__link">Monitoring </a> </li>
+    </ul>);
+}
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Employer, content = HeroHeadingContent() })
+}
 
 @section Resources {
     <partial name="./Components/Resources/_employer" />

--- a/src/SFA.DAS.Campaign.Web/Views/Employer/TheRightApprenticeship.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Employer/TheRightApprenticeship.cshtml
@@ -2,7 +2,6 @@
 @using SFA.DAS.Campaign.Web.Constants
 @using SFA.DAS.Campaign.Web.ViewComponents.Modal
 @model object
-
 @{
     ViewBag.Title = "The right apprenticeship";
     ViewBag.MetaTitle = "The right apprenticeship";
@@ -12,11 +11,11 @@
     Layout = "_LayoutContentSidebar";
 }
 <!--<a id="#<what-apprentice>"></a>-->
-<h2 class="heading-m">Which apprenticeship is right for my organisation?</h2>
+<h2 class="heading-m" id="h1">Which apprenticeship is right for my organisation?</h2>
 
 <p>
     Apprentices will spend at least 20% of their time on off-the-job
-    training with your chosen training provider.  Apprenticeships offer the opportunity to have a flexible, 
+    training with your chosen training provider.  Apprenticeships offer the opportunity to have a flexible,
     but structured training programme, that meet your organisation needs.
 
 </p>
@@ -33,8 +32,9 @@
 <p>
     Apprenticeships are being developed, approved and added all the time.
     Keep a lookout for new apprenticeships that have been added and make sure that you
-    <a href="https://findapprenticeshiptraining.sfa.bis.gov.uk/" target="_blank" rel="external" id="link-fat"> 
-    find the right apprenticeship </a> to
+    <a href="https://findapprenticeshiptraining.sfa.bis.gov.uk/" target="_blank" rel="external" id="link-fat">
+        find the right apprenticeship
+    </a> to
     meet your organisational needs.
 </p>
 
@@ -51,7 +51,7 @@
     </li>
 </ul>
 
-<h2 class="heading-m">I want to find an apprentice for my organisation</h2>
+<h2 class="heading-m" id="h2">I want to find an apprentice for my organisation</h2>
 
 <p>
     If you’re interested in taking on an apprentice you should know:
@@ -76,7 +76,7 @@
 </ul>
 
 <a id="types-of-apprenticeships"></a>
-<h2 class="heading-m">Types of apprenticeships</h2>
+<h2 class="heading-m" id="h3">Types of apprenticeships</h2>
 <p>
     Apprentices must work towards an approved apprenticeship.  Their training must last at least 12 months.
 </p>
@@ -87,11 +87,11 @@
 
 <h3 class="heading-s">Apprenticeship standards</h3>
 <p>
-   Designed by groups of employers, apprenticeship standards set out the knowledge, 
-   skills and behaviours the apprentice needs to be competent in a particular occupation. 
-   <a href="https://www.instituteforapprenticeships.org/developing-apprenticeships/what-is-an-apprenticeship-standard/">The Institute for Apprenticeships</a> 
-   is responsible for the development and approval of standards and works with employers 
-   to ensure a wide range of high-quality apprenticeship standards are available.
+    Designed by groups of employers, apprenticeship standards set out the knowledge,
+    skills and behaviours the apprentice needs to be competent in a particular occupation.
+    <a href="https://www.instituteforapprenticeships.org/developing-apprenticeships/what-is-an-apprenticeship-standard/">The Institute for Apprenticeships</a>
+    is responsible for the development and approval of standards and works with employers
+    to ensure a wide range of high-quality apprenticeship standards are available.
 </p>
 
 <h3 class="heading-s">Apprenticeship frameworks</h3>
@@ -113,10 +113,17 @@
     <li class="pagination__list-item"><a class="pagination__link pagination__link--next" asp-controller="Employer" asp-action="ChooseATrainingProvider" id="link-pagination-employer-3"> Choose a training provider</a></li>
 </ul>
 
+@{
 
+    IHtmlContent HeroHeadingContent() => Helper.Body(@<ul class="list list--arrows">
+        <li><a href="#h1" class="hero__link">Which apprenticeship is right for my organisation? </a> </li>
+        <li><a href="#h2" class="hero__link">I want to find an apprentice for my organisation </a> </li>
+        <li><a href="#h3" class="hero__link">Types of apprenticeships </a> </li>
+    </ul>);
+}
 
 @section HeroHeading {
-    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Employer })
+    @await Component.InvokeAsync("HeroHeading", new { type = HeroHeadingType.Employer, content = HeroHeadingContent() })
 }
 
 @section Resources {

--- a/src/SFA.DAS.Campaign.Web/Views/Home/Index.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Home/Index.cshtml
@@ -2,7 +2,7 @@
     Layout = "_Layout-campaign";
     ViewBag.Title = "Employ an apprentice and become an apprentice";
     ViewBag.PageID = "homepage";
-    ViewBag.MetaDesc = "Everything you need to know about how apprenticeships can fire up your career or business.";
+    ViewBag.MetaDesc = "Everything you need to know about how apprenticeships can fire up your career or organisation.";
 }
 <main id="main-content">
     <h1 class="homepage-title">Fire <span>it up</span></h1>

--- a/src/SFA.DAS.Campaign.Web/Views/Home/Index.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Home/Index.cshtml
@@ -54,7 +54,7 @@
             </h2>
             <div class="grid-row hero-banner__content">
                 <div class="grid-column-one-half  hero-banner__icon-play-container">
-                    <a class="hero-banner__icon-play" href="#player-1" id="play-1" data-module="videoPlayer" data-playerclass="video-player--employer" data-videoplayerid="plyr-1" data-videourl="https://www.youtube.com/embed/I1Cmn0KkR0Q?iv_load_policy=3&amp;modestbranding=1&amp;playsinline=1&amp;showinfo=0&amp;rel=0&amp;enablejsapi=1"></a>
+                    <a class="hero-banner__icon-play" href="#player-1" id="play-1" data-module="videoPlayer" data-playerclass="video-player--employer" data-videoplayerid="plyr-1" data-videourl="https://www.youtube.com/embed/I1Cmn0KkR0Q?origin=https://@(Context.Request.Host.Value)&amp;iv_load_policy=3&amp;modestbranding=1&amp;playsinline=1&amp;showinfo=0&amp;rel=0&amp;enablejsapi=1"></a>
                 </div>
                 <div class="grid-column-one-half hero-banner__content-main">
                     <p class="hero-banner__header">Get the confidence, grab the career.</p>
@@ -77,7 +77,7 @@
             </h2>
             <div class="grid-row hero-banner__content">
                 <div class="grid-column-one-half  hero-banner__icon-play-container">
-                    <a class="hero-banner__icon-play" href="#player-2" id="play-2" data-module="videoPlayer" data-playerclass="video-player--employer" data-videoplayerid="plyr-2" data-videourl="https://www.youtube.com/embed/YwV1siw7reo?iv_load_policy=3&amp;modestbranding=1&amp;playsinline=1&amp;showinfo=0&amp;rel=0&amp;enablejsapi=1"></a>
+                    <a class="hero-banner__icon-play" href="#player-2" id="play-2" data-module="videoPlayer" data-playerclass="video-player--employer" data-videoplayerid="plyr-2" data-videourl="https://www.youtube.com/embed/YwV1siw7reo?origin=https://@(Context.Request.Host.Value)&amp;iv_load_policy=3&amp;modestbranding=1&amp;playsinline=1&amp;showinfo=0&amp;rel=0&amp;enablejsapi=1"></a>
                 </div>
                 <div class="grid-column-one-half hero-banner__content-main">
                     <p class="hero-banner__header">A real win-win for businesses, large and small.</p>

--- a/src/SFA.DAS.Campaign.Web/Views/Shared/Components/Form/cookieSettings.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Shared/Components/Form/cookieSettings.cshtml
@@ -29,7 +29,7 @@
                 <div class="grid-row toggleContainer">
                     <div class="grid-column-one-quarter">
 
-                        <input type="checkbox" name="cbxMarketingConsent" id="cbxMarketingConsent" onchange="setChecked(this,'MarketingConsent')" checked>
+                        <input type="checkbox" name="cbxMarketingConsent" id="cbxMarketingConsent" checked>
                         <label for="cbxMarketingConsent" data-on="ON" data-off="OFF"></label>
 
                     </div>
@@ -44,7 +44,7 @@
                 <div class="grid-row toggleContainer">
                     <div class="grid-column-one-quarter">
 
-                        <input type="checkbox" name="cbxAnalyticsConsent" id="cbxAnalyticsConsent" onchange="setChecked(this,'AnalyticsConsent')" checked>
+                        <input type="checkbox" name="cbxAnalyticsConsent" id="cbxAnalyticsConsent" checked>
                         <label for="cbxAnalyticsConsent" data-on="ON" data-off="OFF"></label>
 
                     </div>


### PR DESCRIPTION
- Header jump links for Apprentice and Employer pages
- Added origin attribute to YouTube videos on the homepage to prevent JS error
- Changed 'business' to 'organisation' in homepage meta description