### PR TITLE
FC-305 - Add check for header already existing

### DIFF
--- a/src/SFA.DAS.Campaign.Web/Startup.cs
+++ b/src/SFA.DAS.Campaign.Web/Startup.cs
@@ -125,7 +125,13 @@ namespace SFA.DAS.Campaign.Web
 
             app.Use(async (context, next) =>
             {
+                if (context.Response.Headers.ContainsKey("X-Frame-Options"))
+                {
+                    context.Response.Headers.Remove("X-Frame-Options");
+                }
+
                 context.Response.Headers.Add("X-Frame-Options", "SAMEORIGIN");
+                
                 await next();
 
                 if (context.Response.StatusCode == 404 && !context.Response.HasStarted)


### PR DESCRIPTION
Add check for the X-Frame-Options header, if it exists, then remove and
re-add it with the SAMEORIGIN value