### PR TITLE
FC-1166 removes hard coded baseurl as config was already set up

### DIFF
--- a/src/SFA.DAS.Vacancies.Api/LivevacanciesAPI.cs
+++ b/src/SFA.DAS.Vacancies.Api/LivevacanciesAPI.cs
@@ -128,7 +128,6 @@ namespace VacanciesApi
         /// </summary>
         private void Initialize()
         {
-            BaseUri = new System.Uri("https://apis.apprenticeships.sfa.bis.gov.uk/vacancies");
             SerializationSettings = new JsonSerializerSettings
             {
                 Formatting = Newtonsoft.Json.Formatting.Indented,


### PR DESCRIPTION
The baseurl that was set in the constructor initialise method was redundant as it is not used and the baseurl was set from config in the startup file