### PR TITLE
FC-1375 breadcrumb updates

### DIFF
--- a/src/SFA.DAS.Campaign.UnitTests/Web/ViewComponents/WhenRenderingTheHeroHeadingViewComponent.cs
+++ b/src/SFA.DAS.Campaign.UnitTests/Web/ViewComponents/WhenRenderingTheHeroHeadingViewComponent.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using Microsoft.AspNetCore.Mvc.ViewComponents;
 using NUnit.Framework;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using SFA.DAS.Campaign.Web.ViewComponents;
 using SFA.DAS.Campaign.Web.ViewComponents.HeroHeading;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Microsoft.AspNetCore.Mvc.Routing;
 
 namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
 {
@@ -14,19 +16,24 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
         private HeroHeadingViewComponent _sut;
         private HeroHeadingViewModel _sutModel;
 
+        private Mock<IUrlHelper> _mockUrlHelper;
+
         [SetUp]
         public void Arrange()
         {
             _sut = new HeroHeadingViewComponent();
             _sutModel = new HeroHeadingViewModel();
-            
 
+            _mockUrlHelper = new Mock<IUrlHelper>();
+
+            _sut.Url = _mockUrlHelper.Object;
         }
 
         [Test]
         public void When_Default_Then_The_Type_Is_None_And_No_Caption()
         {
             _sutModel.Type = HeroHeadingType.None;
+            
             //Act
             var actual = _sut.Invoke(_sutModel);
 
@@ -40,7 +47,7 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
             var headingViewModel = (HeroHeadingViewModel) result.ViewData.Model;
 
             Assert.AreEqual(_sutModel.Type, headingViewModel.Type);
-            Assert.AreEqual(String.Empty,headingViewModel.Caption);
+            Assert.AreEqual(String.Empty,headingViewModel.SectionTitle);
 
         }
 
@@ -48,7 +55,9 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
         public void When_Apprentice_Then_The_Type_Is_Apprentice_And_Caption_Is_Apprentice()
         {
             _sutModel.Type = HeroHeadingType.Apprentice;
-            _sutModel.Caption = "Apprentice";
+            _sutModel.SectionTitle = "Apprentice";
+            _mockUrlHelper.Setup(url => url.Action(It.IsAny<UrlActionContext>())).Returns("www.apprenticeships.gov.uk/real-stories/apprentice");
+
             //Act
             var actual = _sut.Invoke(_sutModel);
 
@@ -62,14 +71,16 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
             var headingViewModel = (HeroHeadingViewModel)result.ViewData.Model;
 
             Assert.AreEqual(_sutModel.Type, headingViewModel.Type);
-            Assert.AreEqual(_sutModel.Caption, headingViewModel.Caption);
+            Assert.AreEqual(_sutModel.SectionTitle, headingViewModel.SectionTitle);
         }
 
         [Test]
         public void When_Employer_Then_The_Type_Is_Employer_And_Caption_Is_Employer()
         {
             _sutModel.Type = HeroHeadingType.Apprentice;
-            _sutModel.Caption = "Employer";
+            _sutModel.SectionTitle = "Employer";
+            _mockUrlHelper.Setup(url => url.Action(It.IsAny<UrlActionContext>())).Returns("www.apprenticeships.gov.uk/real-stories/employer");
+
             //Act
             var actual = _sut.Invoke(_sutModel);
 
@@ -83,14 +94,16 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
             var headingViewModel = (HeroHeadingViewModel)result.ViewData.Model;
 
             Assert.AreEqual(_sutModel.Type, headingViewModel.Type);
-            Assert.AreEqual(_sutModel.Caption, headingViewModel.Caption);
+            Assert.AreEqual(_sutModel.SectionTitle, headingViewModel.SectionTitle);
         }
 
         [Test]
         public void When_Employer_And_Custom_Caption_Then_The_Type_Is_Employer_And_Caption_Custom()
         {
             _sutModel.Type = HeroHeadingType.Employer;
-            _sutModel.Caption = "Custom";
+            _sutModel.SectionTitle = "Custom";
+            _mockUrlHelper.Setup(url => url.Action(It.IsAny<UrlActionContext>())).Returns("www.apprenticeships.gov.uk/real-stories/employer");
+
             //Act
             var actual = _sut.Invoke(_sutModel);
 
@@ -104,14 +117,15 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
             var headingViewModel = (HeroHeadingViewModel)result.ViewData.Model;
 
             Assert.AreEqual(_sutModel.Type, headingViewModel.Type);
-            Assert.AreEqual(_sutModel.Caption, headingViewModel.Caption);
+            Assert.AreEqual(_sutModel.SectionTitle, headingViewModel.SectionTitle);
         }
 
         [Test]
         public void When_Apprentice_And_Custom_Caption_Then_The_Type_Is_Apprentice_And_Caption_Custom()
         {
             _sutModel.Type = HeroHeadingType.Apprentice;
-            _sutModel.Caption = "Custom";
+            _sutModel.SectionTitle = "Custom";
+            _mockUrlHelper.Setup(url => url.Action(It.IsAny<UrlActionContext>())).Returns("www.apprenticeships.gov.uk/real-stories/apprentice");
 
             //Act
             var actual = _sut.Invoke(_sutModel);
@@ -126,7 +140,7 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
             var headingViewModel = (HeroHeadingViewModel)result.ViewData.Model;
 
             Assert.AreEqual(_sutModel.Type, headingViewModel.Type);
-            Assert.AreEqual(_sutModel.Caption, headingViewModel.Caption);
+            Assert.AreEqual(_sutModel.SectionTitle, headingViewModel.SectionTitle);
         }
 
         [Test]
@@ -136,6 +150,7 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
             var customClass = "custom-employer-class";
             _sutModel.Class = customClass;
             var actualClass = "hero-heading__caption--employer " + customClass;
+            _mockUrlHelper.Setup(url => url.Action(It.IsAny<UrlActionContext>())).Returns("www.apprenticeships.gov.uk/real-stories/employer");
 
             //Act
             var actual = _sut.Invoke(_sutModel);
@@ -160,6 +175,8 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
             var customClass = "custom-apprentice-class";
             _sutModel.Class = customClass;
             var actualClass = "hero-heading__caption--apprentice " + customClass;
+            _mockUrlHelper.Setup(url => url.Action(It.IsAny<UrlActionContext>())).Returns("www.apprenticeships.gov.uk/real-stories/apprentice");
+
             //Act
             var actual = _sut.Invoke(_sutModel);
 
@@ -181,6 +198,8 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
         {
             _sutModel.Type = HeroHeadingType.Apprentice;
             _sutModel.Content = customContent();
+            _mockUrlHelper.Setup(url => url.Action(It.IsAny<UrlActionContext>())).Returns("www.apprenticeships.gov.uk/real-stories/apprentice");
+
             //Act
             var actual = _sut.Invoke(_sutModel);
 
@@ -204,8 +223,7 @@ namespace SFA.DAS.Campaign.Web.UnitTests.Controllers.Home
             _sutModel.Content = customContent();
             _sutModel.ImageUrl = "testimage.jpg";
             _sutModel.ImageAltText = "Header image description";
-
-
+            _mockUrlHelper.Setup(url => url.Action(It.IsAny<UrlActionContext>())).Returns("www.apprenticeships.gov.uk/real-stories/employer");
 
             //Act
             var actual = _sut.Invoke(_sutModel);

--- a/src/SFA.DAS.Campaign.Web/ViewComponents/Hero-Heading/HeroHeadingViewComponent.cs
+++ b/src/SFA.DAS.Campaign.Web/ViewComponents/Hero-Heading/HeroHeadingViewComponent.cs
@@ -23,10 +23,13 @@ namespace SFA.DAS.Campaign.Web.ViewComponents
                 case HeroHeadingType.None:
                     break;
                 case HeroHeadingType.Apprentice:
+                    model.SectionUrl = Url.Action("Apprentice", "RealStories");
                     break;
                 case HeroHeadingType.Employer:
+                    model.SectionUrl = Url.Action("Employer", "RealStories");
                     break;
                 case HeroHeadingType.Parent:
+                    model.SectionUrl = Url.Action("TheirCareer", "Parents");
                     break;
                 case HeroHeadingType.FindApprenticeshipResults:
                     model.Type = HeroHeadingType.Apprentice;
@@ -34,10 +37,12 @@ namespace SFA.DAS.Campaign.Web.ViewComponents
                     break;
                 case HeroHeadingType.FindApprenticeship:
                     model.Type = HeroHeadingType.Apprentice;
+                    model.SectionUrl = Url.Action("Apprentice", "RealStories");
                     view = "FAA";
                     break;
                 case HeroHeadingType.FindApprenticeshipTraining:
                     model.Type = HeroHeadingType.Employer;
+                    model.SectionUrl = Url.Action("Employer", "RealStories");
                     view = "FAT";
                     break;
 

--- a/src/SFA.DAS.Campaign.Web/ViewComponents/Hero-Heading/HeroHeadingViewModel.cs
+++ b/src/SFA.DAS.Campaign.Web/ViewComponents/Hero-Heading/HeroHeadingViewModel.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.Campaign.Web.ViewComponents
         private HeroHeadingType _type;
         private string _controller;
         private string _class;
-        private string _caption;
+        private string _sectionTitle;
 
         public IHtmlContent Content { get; set; }
 
@@ -50,11 +50,11 @@ namespace SFA.DAS.Campaign.Web.ViewComponents
             set => _type = value;
         }
 
-        public string Caption
+        public string SectionTitle
         {
             get
             {
-                if (String.IsNullOrWhiteSpace(_caption))
+                if (String.IsNullOrWhiteSpace(_sectionTitle))
                 {
                     switch (_type)
                     {
@@ -63,15 +63,15 @@ namespace SFA.DAS.Campaign.Web.ViewComponents
                         case HeroHeadingType.Employer:
                             return "Employer";
                         case HeroHeadingType.Parent:
-                            return "Parent";
+                            return "Parents";
                     }
                     return String.Empty;
                 }
 
-                return _caption;
+                return _sectionTitle;
 
             }
-            set => _caption = value;
+            set => _sectionTitle = value;
         }
 
         public string Class
@@ -104,5 +104,9 @@ namespace SFA.DAS.Campaign.Web.ViewComponents
         public string ImageUrl { get; set; }
         public string ImageAltText { get; set; }
         public string Controller { internal get; set; }
+
+        public string SectionUrl { get; set; }
+        public string SubSectionTitle { get; set; }
+        public string SubSectionUrl { get; set; }
     }
 }

--- a/src/SFA.DAS.Campaign.Web/Views/Apprentice/Application.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Apprentice/Application.cshtml
@@ -1,4 +1,6 @@
-﻿@{
+﻿@using SFA.DAS.Campaign.Web.ViewComponents
+@using SFA.DAS.Campaign.Web.ViewComponents.HeroHeading
+@{
     ViewBag.Title = "Application";
     ViewBag.MetaTitle = "How to apply for an apprenticeship and what's needed from you";
     ViewBag.PageID = "apprentice-application";
@@ -79,6 +81,10 @@
         <a class="pagination__link pagination__link--next" asp-controller="Apprentice" asp-action="Interview" id="link-pagination-apprentice-4">Interview </a>
     </li>
 </ul>
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel() { Type = HeroHeadingType.Apprentice })
+}
 
 @section pageFooter {
     <div class="grid-column-full">

--- a/src/SFA.DAS.Campaign.Web/Views/Apprentice/RedirectToFAA.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Apprentice/RedirectToFAA.cshtml
@@ -19,3 +19,7 @@
         <a href="https://www.gov.uk/apply-apprenticeship" target="_blank" class="button button-apprentice"> Find an apprenticeship on GOV.UK</a>
     </div>
 </div>
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel() { Type = HeroHeadingType.Apprentice })
+} 

--- a/src/SFA.DAS.Campaign.Web/Views/Basket/Confirm.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Basket/Confirm.cshtml
@@ -48,5 +48,5 @@
 }
 
 @section HeroHeading {
-    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel(){ Content = HeroHeadingContent() , Caption = ViewBag.Caption, ImageUrl = ViewBag.ImageUrl, ImageAltText = ViewBag.ImageAltText})
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel(){ Content = HeroHeadingContent() , SectionTitle = ViewBag.Caption, ImageUrl = ViewBag.ImageUrl, ImageAltText = ViewBag.ImageAltText})
 }

--- a/src/SFA.DAS.Campaign.Web/Views/Employer/AssessmentAndQualification.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Employer/AssessmentAndQualification.cshtml
@@ -80,7 +80,7 @@
 }
 
 @section HeroHeading {
-    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel(){ Type = HeroHeadingType.Employer, Content = HeroHeadingContent() })
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel(){ Type = HeroHeadingType.Employer, Content = HeroHeadingContent(), SubSectionTitle = "How do they work?", SubSectionUrl = Url.Action("Index", "HowDoTheyWork")  })
 }
 
 @section Resources {

--- a/src/SFA.DAS.Campaign.Web/Views/EmployerInform/EndPointAssessments.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/EmployerInform/EndPointAssessments.cshtml
@@ -1,4 +1,6 @@
-﻿@model object
+﻿@using SFA.DAS.Campaign.Web.ViewComponents
+@using SFA.DAS.Campaign.Web.ViewComponents.HeroHeading
+@model object
 @{
     ViewBag.Title = "End-point Assessments";
     ViewBag.MetaTitle = "Apprenticeship end-point assessment";
@@ -33,11 +35,11 @@
 <h2 class="heading-m">The cost of an end-point assessment</h2>
 
 <p>We expect that the cost of the end-point assessment will not usually exceed 20% of the funding band maximum. This cost is included in the overall price agreed with the training provider for the apprenticeship.</p>
-   
+
 <h2 class="heading-m">Certification</h2>
 
 <p>When your apprentice successfully completes their apprenticeship, they'll be awarded a certificate. The end-point assessment organisation will request this certificate on your behalf.</p>
-   
+
 <ul class="pagination pagination--employer">
     <li class="pagination__list-item pagination__list-item--previous">
         <a class="pagination__link pagination__link--previous" asp-action="Index" asp-controller="TrainingYourApprentice">Training your apprentice</a>
@@ -46,6 +48,10 @@
         <a class="pagination__link pagination__link--next" asp-action="TheRightApprenticeship" asp-controller="Employer">Choosing the right apprenticeship</a>
     </li>
 </ul>
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel() { Type = HeroHeadingType.Employer, SubSectionTitle = "How do they work?", SubSectionUrl = Url.Action("Index", "HowDoTheyWork") })
+}
 
 @section pageFooter {
     <div class="grid-column-full">

--- a/src/SFA.DAS.Campaign.Web/Views/EmployerInform/FundingAnApprenticeship.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/EmployerInform/FundingAnApprenticeship.cshtml
@@ -1,4 +1,6 @@
-﻿@using SFA.DAS.Campaign.Web.Controllers.EmployerInform
+﻿@using SFA.DAS.Campaign.Web.ViewComponents
+@using SFA.DAS.Campaign.Web.ViewComponents.HeroHeading
+@using SFA.DAS.Campaign.Web.Controllers.EmployerInform
 @model SFA.DAS.Campaign.Web.Controllers.EmployerInform.LevyOptionViewModel
 @{
     ViewBag.Title = "Funding an apprenticeship";
@@ -19,94 +21,94 @@
 
 @if (Model.LevyStatus == LevyStatus.Levy)
 {
-        <h2 class="heading-m">Apprenticeship funding from the government</h2>
-        <h3 class="heading-s">Apprenticeship training and assessment</h3>
-        <p>
-            As an employer with a pay bill of more than £3 million, you're required to pay the apprenticeship levy.
-            You'll receive funds through the apprenticeship service to spend on training and assessing your apprentices.
-        </p>
-        <p>
-            The amount of funding entering your account each month is calculated as follows:
-        </p>
-        <ul class="list list--bullet list--bullet-employer">
-            <li>the levy you declare to HMRC through the <a href="https://www.gov.uk/paye-for-employers/paye-and-payroll" target="_blank" rel="external" class="external">PAYE process</a></li>
-            <li>multiplied by the proportion of your bill paid to your workforce who live in England</li>
-            <li>plus a 10% government top-up on this amount</li>
-        </ul>
-        <p>
-            When you're ready to get started, you'll need to
-            <a href="/campaign/employer/gov-transition-NO-FAT" class="external">sign in or create a new account</a>
-            on the apprenticeship service.
-        </p>
-   
+    <h2 class="heading-m">Apprenticeship funding from the government</h2>
+    <h3 class="heading-s">Apprenticeship training and assessment</h3>
+    <p>
+        As an employer with a pay bill of more than £3 million, you're required to pay the apprenticeship levy.
+        You'll receive funds through the apprenticeship service to spend on training and assessing your apprentices.
+    </p>
+    <p>
+        The amount of funding entering your account each month is calculated as follows:
+    </p>
+    <ul class="list list--bullet list--bullet-employer">
+        <li>the levy you declare to HMRC through the <a href="https://www.gov.uk/paye-for-employers/paye-and-payroll" target="_blank" rel="external" class="external">PAYE process</a></li>
+        <li>multiplied by the proportion of your bill paid to your workforce who live in England</li>
+        <li>plus a 10% government top-up on this amount</li>
+    </ul>
+    <p>
+        When you're ready to get started, you'll need to
+        <a href="/campaign/employer/gov-transition-NO-FAT" class="external">sign in or create a new account</a>
+        on the apprenticeship service.
+    </p>
+
 }
 else
 {
 
-        <h2 class="heading-m">Apprenticeship funding from the government</h2>
-        <h3 class="heading-s">Apprenticeship training and assessment</h3>
+    <h2 class="heading-m">Apprenticeship funding from the government</h2>
+    <h3 class="heading-s">Apprenticeship training and assessment</h3>
 
-        <p>
-            As an employer with a pay bill of less than £3 million per year, you'll share apprenticeship costs with
-            the government if you have at least 50 employees. This means:
-        </p>
+    <p>
+        As an employer with a pay bill of less than £3 million per year, you'll share apprenticeship costs with
+        the government if you have at least 50 employees. This means:
+    </p>
 
-        <ul class="list list--bullet list--bullet-employer">
-            <li>you'll pay 5% towards the cost of training and assessing your apprentice</li>
-            <li>the government will pay the remaining 95%, up to the&nbsp;<a href="https://www.gov.uk/government/publications/apprenticeship-funding-bands" target="_blank" rel="external" class="external">funding band maximum</a></li>
-            <li>if your apprentice's training and assessment cost more than this, you'll pay the difference</li>
-        </ul>
+    <ul class="list list--bullet list--bullet-employer">
+        <li>you'll pay 5% towards the cost of training and assessing your apprentice</li>
+        <li>the government will pay the remaining 95%, up to the&nbsp;<a href="https://www.gov.uk/government/publications/apprenticeship-funding-bands" target="_blank" rel="external" class="external">funding band maximum</a></li>
+        <li>if your apprentice's training and assessment cost more than this, you'll pay the difference</li>
+    </ul>
 
-        <h2 class="heading-s no-top-margin">Employers with fewer than 50 employees</h2>
+    <h2 class="heading-s no-top-margin">Employers with fewer than 50 employees</h2>
 
-        <p>
-            If you're an employer with fewer than 50 employees, the government will fund all the apprenticeship training
-            costs up to the
-            <a href="https://www.gov.uk/government/publications/apprenticeship-funding-bands" target="_blank" rel="external" class="external">funding band maximum</a>
-            if the apprentice is:
-        </p>
+    <p>
+        If you're an employer with fewer than 50 employees, the government will fund all the apprenticeship training
+        costs up to the
+        <a href="https://www.gov.uk/government/publications/apprenticeship-funding-bands" target="_blank" rel="external" class="external">funding band maximum</a>
+        if the apprentice is:
+    </p>
 
-        <ul class="list list--bullet list--bullet-employer">
-            <li>between 16 and 18 years old (or 15 years old if the apprentice's 16th birthday is between the last Friday of June and 31 August)</li>
-            <li>between 19 and 24 years old and has either an Education, Health and Care (EHC) plan provided by their local authority or has been in the care of their local authority</li>
-        </ul>
+    <ul class="list list--bullet list--bullet-employer">
+        <li>between 16 and 18 years old (or 15 years old if the apprentice's 16th birthday is between the last Friday of June and 31 August)</li>
+        <li>between 19 and 24 years old and has either an Education, Health and Care (EHC) plan provided by their local authority or has been in the care of their local authority</li>
+    </ul>
 
-        <p>
-            This means you won't have to pay the 5% co-investment amount.
-        </p>
+    <p>
+        This means you won't have to pay the 5% co-investment amount.
+    </p>
 
-        <h2 class="heading-m">Training young apprentices</h2>
+    <h2 class="heading-m">Training young apprentices</h2>
 
-        <p>
-            All employers will receive <strong>£1,000</strong> if, at the start of the apprenticeship, the apprentice is:
-        </p>
+    <p>
+        All employers will receive <strong>£1,000</strong> if, at the start of the apprenticeship, the apprentice is:
+    </p>
 
-        <ul class="list list--bullet list--bullet-employer">
-            <li>between 16 and 18 years old (or 15 years old if the apprentice's 16th birthday is between the last Friday of June and 31 August)</li>
-            <li>between 19 and 24 years old and has either an Education, Health and Care (EHC) plan provided by their local authority or has been in the care of their local authority</li>
-        </ul>
+    <ul class="list list--bullet list--bullet-employer">
+        <li>between 16 and 18 years old (or 15 years old if the apprentice's 16th birthday is between the last Friday of June and 31 August)</li>
+        <li>between 19 and 24 years old and has either an Education, Health and Care (EHC) plan provided by their local authority or has been in the care of their local authority</li>
+    </ul>
 
-        <p>
-            This will be paid to you in two equal instalments, 3 months and 12 months into the apprenticeships, via your training provider.
-        </p>
+    <p>
+        This will be paid to you in two equal instalments, 3 months and 12 months into the apprenticeships, via your training provider.
+    </p>
 
-        <h2 class="heading-m">Example training and assessment costs</h2>
+    <h2 class="heading-m">Example training and assessment costs</h2>
 
-        <p>
-            These examples show the breakdown of costs for funding an apprentice's training and assessment. They do not include other
-            costs, such as salary, which are detailed below.
-        </p>
+    <p>
+        These examples show the breakdown of costs for funding an apprentice's training and assessment. They do not include other
+        costs, such as salary, which are detailed below.
+    </p>
 
-        <h2 class="heading-s">Example costs 1:</h2>
+    <h2 class="heading-s">Example costs 1:</h2>
 
-        <table class="table table--employer">
-            <thead class="table__header">
+    <table class="table table--employer">
+        <thead class="table__header">
             <tr class="table__row table__header-row">
                 <th class="table__cell table__row-title table__header-row-title">Financial services administrator</th>
                 <th class="table__cell  table__row-value--header">Level 3 - (<a href="https://www.gov.uk/what-different-qualification-levels-mean/list-of-qualification-levels" target="_blank" rel="external" id="link-qualification-levels-1">levels explained</a>)</th>
             </tr>
-            </thead>
-            <tbody class="table__body">
+        </thead>
+        <tbody class="table__body">
             <tr class="table__row">
                 <th class="table__cell table__row-title" scope="row">Number of apprentices</th>
                 <td class="table__cell">1</td>
@@ -123,25 +125,25 @@ else
                 <th class="table__cell table__row-title" scope="row">The government will pay</th>
                 <td class="table__cell">£11,400</td>
             </tr>
-            </tbody>
-            <tfoot class="table__footer">
+        </tbody>
+        <tfoot class="table__footer">
             <tr class="table__row">
                 <th class="table__cell table__row-title" scope="row">Cost to you</th>
                 <td class="table__cell">£600</td>
             </tr>
-            </tfoot>
-        </table>
+        </tfoot>
+    </table>
 
-        <h2 class="heading-s">Example costs 2:</h2>
+    <h2 class="heading-s">Example costs 2:</h2>
 
-        <table class="table table--employer">
-            <thead class="table__header">
+    <table class="table table--employer">
+        <thead class="table__header">
             <tr class="table__row table__header-row">
                 <th class="table__cell table__row-title table__row-title--header">Rail Infrastructure Operator</th>
                 <th class="table__cell table__row-value--header">Level 2 - (<a href="https://www.gov.uk/what-different-qualification-levels-mean/list-of-qualification-levels" target="_blank" rel="external" id="link-qualification-levels-2">levels explained</a>)</th>
             </tr>
-            </thead>
-            <tbody class="table__body">
+        </thead>
+        <tbody class="table__body">
             <tr class="table__row">
                 <th class="table__cell table__row-title" scope="row">Number of apprentices</th>
                 <td class="table__cell">1</td>
@@ -158,15 +160,15 @@ else
                 <th class="table__cell table__row-title" scope="row">The government will pay</th>
                 <td class="table__cell">£9,500</td>
             </tr>
-            </tbody>
-            <tfoot class="table__footer">
+        </tbody>
+        <tfoot class="table__footer">
             <tr class="table__row">
                 <th class="table__cell table__row-title" scope="row">Cost to you</th>
                 <td class="table__cell">£500</td>
             </tr>
-            </tfoot>
-        </table>
-    
+        </tfoot>
+    </table>
+
 }
 
 <h2 class="heading-m" id="heading3">Apprenticeship costs paid by you</h2>
@@ -205,25 +207,25 @@ else
 {
 
 
-        <h2 class="heading-m">Transferring funds to another employer</h2>
-        <p>
-            If you have unused apprenticeship funds, you can
-            <a href="https://www.gov.uk/guidance/transferring-apprenticeship-service-funds" target="_blank" rel="external">
-                transfer them to another employer
-                using the apprenticeship service
-            </a>.
-        </p>
+    <h2 class="heading-m">Transferring funds to another employer</h2>
+    <p>
+        If you have unused apprenticeship funds, you can
+        <a href="https://www.gov.uk/guidance/transferring-apprenticeship-service-funds" target="_blank" rel="external">
+            transfer them to another employer
+            using the apprenticeship service
+        </a>.
+    </p>
 
-        <p>
-            You can find employers who want to receive a transfer by:
-        </p>
+    <p>
+        You can find employers who want to receive a transfer by:
+    </p>
 
-        <ul class="list list--bullet list--bullet-employer">
-            <li>working with employers in your supply chain</li>
-            <li>getting in touch with employers in your industry</li>
-            <li>contacting an Apprenticeship Training Agency (ATA)</li>
-            <li>working with regional partners</li>
-        </ul>
+    <ul class="list list--bullet list--bullet-employer">
+        <li>working with employers in your supply chain</li>
+        <li>getting in touch with employers in your industry</li>
+        <li>contacting an Apprenticeship Training Agency (ATA)</li>
+        <li>working with regional partners</li>
+    </ul>
 }
 
 <h2 class="heading-m">Paying for apprenticeships using a transfer of apprenticeship funds</h2>
@@ -261,8 +263,12 @@ else
     </li>
 </ul>
 
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel() { Type = HeroHeadingType.Employer, SubSectionTitle = "How do they work?", SubSectionUrl = Url.Action("Index", "HowDoTheyWork") })
+}
+
 @section pageFooter {
     <div class="grid-column-full">
-        <partial name="./Components/Cta/_find-apprenticeship-training-with-search"/>
+        <partial name="./Components/Cta/_find-apprenticeship-training-with-search" />
     </div>
 }

--- a/src/SFA.DAS.Campaign.Web/Views/EmployerInform/HiringAnApprentice.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/EmployerInform/HiringAnApprentice.cshtml
@@ -1,4 +1,7 @@
 ﻿
+@using SFA.DAS.Campaign.Web.ViewComponents
+@using SFA.DAS.Campaign.Web.ViewComponents.HeroHeading
+
 @model object
 @{
     ViewBag.Title = "Hiring an apprentice";
@@ -9,7 +12,7 @@
     ViewBag.PageUrl = "/employer/hiring-an-apprentice";
     ViewBag.Section = "employer";
     Layout = "_Layout-campaign-employer-inform";
-  }
+}
 
 <h2 class="heading-m">Who can be an apprentice?</h2>
 
@@ -99,6 +102,11 @@
     <li class="pagination__list-item"><a class="pagination__link pagination__link--previous" asp-controller="Employer" asp-action="Benefits" id="link-pagination-employer-3"> The benefits of apprenticeships</a></li>
     <li class="pagination__list-item"><a class="pagination__link pagination__link--next" asp-controller="FundingAnApprenticeship" asp-action="Index" id="link-pagination-employer-5"> Funding an apprenticeship</a></li>
 </ul>
+
+
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel() { Type = HeroHeadingType.Employer, SubSectionTitle = "How do they work?", SubSectionUrl = Url.Action("Index", "HowDoTheyWork")})
+}
 
 @section pageFooter {
     <div class="grid-column-full">

--- a/src/SFA.DAS.Campaign.Web/Views/EmployerInform/TrainingYourApprentice.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/EmployerInform/TrainingYourApprentice.cshtml
@@ -1,4 +1,6 @@
-﻿@model object
+﻿@using SFA.DAS.Campaign.Web.ViewComponents
+@using SFA.DAS.Campaign.Web.ViewComponents.HeroHeading
+@model object
 @{
     ViewBag.Title = "Training your apprentice";
     ViewBag.MetaTitle = "How apprenticeship training works";
@@ -9,7 +11,7 @@
     ViewBag.Section = "employer";
     Layout = "_Layout-campaign-employer-inform";
 }
-    
+
 <h2 class="heading-m">Apprentices are trained to make an impact </h2>
 
 <p>Throughout the apprenticeship, you'll supervise the apprentice and provide them with on-the-job training to help them develop new skills.</p>
@@ -42,7 +44,7 @@
 
 <p>As a rule of thumb, an activity should count towards apprenticeship off-the-job training if you can answer <strong>'yes'</strong> to all these questions:</p>
 
-<ol class="list list--number list--number-employer" >
+<ol class="list list--number list--number-employer">
     <li>Is the person signed up to the apprenticeship programme?</li>
     <li>Is the activity directly relevant to the apprenticeship?</li>
     <li>Is the activity teaching new knowledge, skills and behaviours?</li>
@@ -58,6 +60,9 @@
     <li class="pagination__list-item"><a class="pagination__link pagination__link--next" asp-controller="EndPointAssessments" asp-action="Index" id="link-pagination-employer-5"> End-point assessments</a></li>
 </ul>
 
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel() { Type = HeroHeadingType.Employer, SubSectionTitle = "How do they work?", SubSectionUrl = Url.Action("Index", "HowDoTheyWork") })
+}
 
 @section pageFooter {
     <div class="grid-column-full">

--- a/src/SFA.DAS.Campaign.Web/Views/EmployerInform/Upskill.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/EmployerInform/Upskill.cshtml
@@ -1,4 +1,6 @@
-﻿@model object
+﻿@using SFA.DAS.Campaign.Web.ViewComponents
+@using SFA.DAS.Campaign.Web.ViewComponents.HeroHeading
+@model object
 @{
     ViewBag.Title = "Upskilling your current staff";
     ViewBag.MetaTitle = "Apprenticeships to train your current staff";
@@ -69,8 +71,12 @@
     </li>
 </ul>
 
+@section HeroHeading {
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel() { Type = HeroHeadingType.Employer, SubSectionTitle = "How do they work?", SubSectionUrl = Url.Action("Index", "HowDoTheyWork") })
+}
+
 @section pageFooter {
     <div class="grid-column-full">
-        <partial name="./Components/Cta/_find-apprenticeship-training-with-search"/>
+        <partial name="./Components/Cta/_find-apprenticeship-training-with-search" />
     </div>
 }

--- a/src/SFA.DAS.Campaign.Web/Views/Parents/TheirCareer.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Parents/TheirCareer.cshtml
@@ -199,7 +199,7 @@
 }
 
 @section HeroHeading {
-    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel(){ Content = HeroHeadingContent() })
+    @await Component.InvokeAsync("HeroHeading", new HeroHeadingViewModel(){ Type = HeroHeadingType.Parent, Content = HeroHeadingContent() })
 }
 
 @section Resources {

--- a/src/SFA.DAS.Campaign.Web/Views/Shared/Components/HeroHeading/Default.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Shared/Components/HeroHeading/Default.cshtml
@@ -3,7 +3,20 @@
     <div class="grid-row">
         <div class="grid-column-one-half">
             <div class="hero-heading">
-                <span class="caption-m hero-heading__caption @Model.Class">@Model.Caption</span>
+                <span class="caption-m hero-heading__caption @Model.Class">
+
+                    <a href="@Model.SectionUrl" class="hero-heading__caption-link @Model.Class" style="">@Model.SectionTitle</a>
+                    <span class="hero-heading__caption-separator">&gt;</span>
+
+                    @if (!string.IsNullOrEmpty(Model.SubSectionTitle))
+                    {
+                        <a href="@Model.SubSectionUrl" class="hero-heading__subsection hero-heading__caption-link @Model.Class">@Model.SubSectionTitle</a>
+                        <span class="hero-heading__caption-separator">&gt;</span>
+                    }
+
+                    <span class="hero-heading__caption--current">@ViewContext.ViewBag.Title</span>
+                </span>
+
                 <h1 class="heading-xl hero-heading__heading">@ViewContext.ViewBag.Title</h1>
             </div>
 

--- a/src/SFA.DAS.Campaign.Web/Views/Shared/Components/HeroHeading/FAA.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Shared/Components/HeroHeading/FAA.cshtml
@@ -3,7 +3,12 @@
     <div class="grid-row">
         <div class="grid-column-one-half">
             <div class="hero-heading">
-                <span class="caption-m hero-heading__caption @Model.Class">@Model.Caption</span>
+                <span class="caption-m hero-heading__caption @Model.Class">
+                    <a href="@Model.SectionUrl" class="hero-heading__caption-link @Model.Class" style="">@Model.SectionTitle</a>
+                    <span class="hero-heading__caption-separator">&gt;</span>
+
+                    <span class="hero-heading__caption--current"> @ViewContext.ViewBag.Title </span>
+                </span>
                 <h1 class="heading-xl hero-heading__heading">@ViewContext.ViewBag.Title</h1>
             </div>
 

--- a/src/SFA.DAS.Campaign.Web/Views/Shared/Components/HeroHeading/FAT.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Shared/Components/HeroHeading/FAT.cshtml
@@ -3,7 +3,12 @@
     <div class="grid-row">
         <div class="grid-column-two-thirds">
             <div class="hero-heading">
-                <span class="caption-m hero-heading__caption @Model.Class">@Model.Caption</span>
+                <span class="caption-m hero-heading__caption @Model.Class">
+                    <a href="@Model.SectionUrl" class="hero-heading__caption-link @Model.Class" style="">@Model.SectionTitle</a>
+                    <span class="hero-heading__caption-separator">&gt;</span>
+
+                    <span class="hero-heading__caption--current"> @ViewContext.ViewBag.Title </span>
+                </span>
                 <h1 class="heading-xl hero-heading__heading">@ViewContext.ViewBag.Title</h1>
             </div>
 

--- a/src/SFA.DAS.Campaign.Web/Views/Shared/_Layout-campaign-employer-inform.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Shared/_Layout-campaign-employer-inform.cshtml
@@ -2,51 +2,60 @@
     Layout = "_Layout-campaign-employer";
 }
 
-@section HeadScripts {
-    <script type="application/ld+json">
-    {
-    "@@context": "https://schema.org",
-    "@@type": "BreadcrumbList",
-    "itemListElement": [{
-        "@@type": "ListItem",
-        "position": 1,
-        "name": "How do they work?",
-        "item": "https://www.apprenticeships.gov.uk/employer/how-do-they-work"
-    },{
-        "@@type": "ListItem",
-        "position": 2,
-        "name": "@(ViewBag.Title)",
-        "item": "https://www.apprenticeships.gov.uk/@(ViewBag.PageUrl)"
-    }]
-    }
-    </script>
+@*@section HeadScripts {
+        <script type="application/ld+json">
+        {
+        "@@context": "https://schema.org",
+        "@@type": "BreadcrumbList",
+        "itemListElement": [{
+            "@@type": "ListItem",
+            "position": 1,
+            "name": "How do they work?",
+            "item": "https://www.apprenticeships.gov.uk/employer/how-do-they-work"
+        },{
+            "@@type": "ListItem",
+            "position": 2,
+            "name": "@(ViewBag.Title)",
+            "item": "https://www.apprenticeships.gov.uk/@(ViewBag.PageUrl)"
+        }]
+        }
+        </script>
+    }*@
+
+@if (IsSectionDefined("HeroHeading"))
+{
+    @RenderSection("HeroHeading", required: false)
+}
+else
+{
+    @await Component.InvokeAsync("HeroHeading")
 }
 
 <main id="main-content">
-    <div class="hero">
-        <div class="grid-row">
-            <div class="grid-column-one-half">
-                <div class="hero-heading">
-                    <span class="caption-m hero-heading__caption hero-heading__caption--employer">
-                        <a asp-controller="HowDoTheyWork" asp-action="Index" class="hero-heading__caption--employer hero-heading__caption-link">How do they work?</a> 
-                        <span class="hero-heading__caption-separator">&gt;</span> 
-                        @(ViewBag.Title)
-                    </span>
-                    <h1 class="heading-xl hero-heading__heading">@(ViewBag.Title)</h1>
+    @*<div class="hero">
+            <div class="grid-row">
+                <div class="grid-column-one-half">
+                    <div class="hero-heading">
+                        <span class="caption-m hero-heading__caption hero-heading__caption--employer">
+                            <a asp-controller="HowDoTheyWork" asp-action="Index" class="hero-heading__caption--employer hero-heading__caption-link">How do they work?</a>
+                            <span class="hero-heading__caption-separator">&gt;</span>
+                            @(ViewBag.Title)
+                        </span>
+                        <h1 class="heading-xl hero-heading__heading">@(ViewBag.Title)</h1>
+                    </div>
+
+                    <div class="hero-heading__content">
+
+                        <a href="https://www.gov.uk/" id="header-link-govuk" target="_blank" class="hero-heading__hm-government-link">
+                            <img alt="HM Government" class="hero-heading__hm-government-logo" src="/campaign/images/hm-government-logo.png" srcset="/campaign/images/hm-government-logo.png 1x, /campaign/images/hm-government-logo@2x.png 2x" />
+                        </a>
+                    </div>
                 </div>
+                <div class="grid-column-one-half">
 
-                <div class="hero-heading__content">
-
-                    <a href="https://www.gov.uk/" id="header-link-govuk" target="_blank" class="hero-heading__hm-government-link">
-                        <img alt="HM Government" class="hero-heading__hm-government-logo" src="/campaign/images/hm-government-logo.png" srcset="/campaign/images/hm-government-logo.png 1x, /campaign/images/hm-government-logo@2x.png 2x" />
-                    </a>
                 </div>
             </div>
-            <div class="grid-column-one-half">
-            
-            </div>
-        </div>
-    </div>
+        </div>*@
     <div class="main-content">
         <div class="grid-row">
             <div class="grid-column-two-thirds">
@@ -66,7 +75,7 @@
 
 
                 </div>
-               
+
             </div>
 
         </div>

--- a/src/SFA.DAS.Campaign.Web/Views/Shared/_Layout-campaign-employer-inform.cshtml
+++ b/src/SFA.DAS.Campaign.Web/Views/Shared/_Layout-campaign-employer-inform.cshtml
@@ -2,60 +2,17 @@
     Layout = "_Layout-campaign-employer";
 }
 
-@*@section HeadScripts {
-        <script type="application/ld+json">
-        {
-        "@@context": "https://schema.org",
-        "@@type": "BreadcrumbList",
-        "itemListElement": [{
-            "@@type": "ListItem",
-            "position": 1,
-            "name": "How do they work?",
-            "item": "https://www.apprenticeships.gov.uk/employer/how-do-they-work"
-        },{
-            "@@type": "ListItem",
-            "position": 2,
-            "name": "@(ViewBag.Title)",
-            "item": "https://www.apprenticeships.gov.uk/@(ViewBag.PageUrl)"
-        }]
-        }
-        </script>
-    }*@
-
-@if (IsSectionDefined("HeroHeading"))
-{
-    @RenderSection("HeroHeading", required: false)
-}
-else
-{
-    @await Component.InvokeAsync("HeroHeading")
-}
-
 <main id="main-content">
-    @*<div class="hero">
-            <div class="grid-row">
-                <div class="grid-column-one-half">
-                    <div class="hero-heading">
-                        <span class="caption-m hero-heading__caption hero-heading__caption--employer">
-                            <a asp-controller="HowDoTheyWork" asp-action="Index" class="hero-heading__caption--employer hero-heading__caption-link">How do they work?</a>
-                            <span class="hero-heading__caption-separator">&gt;</span>
-                            @(ViewBag.Title)
-                        </span>
-                        <h1 class="heading-xl hero-heading__heading">@(ViewBag.Title)</h1>
-                    </div>
 
-                    <div class="hero-heading__content">
+    @if (IsSectionDefined("HeroHeading"))
+    {
+        @RenderSection("HeroHeading", required: false)
+    }
+    else
+    {
+        @await Component.InvokeAsync("HeroHeading")
+    }
 
-                        <a href="https://www.gov.uk/" id="header-link-govuk" target="_blank" class="hero-heading__hm-government-link">
-                            <img alt="HM Government" class="hero-heading__hm-government-logo" src="/campaign/images/hm-government-logo.png" srcset="/campaign/images/hm-government-logo.png 1x, /campaign/images/hm-government-logo@2x.png 2x" />
-                        </a>
-                    </div>
-                </div>
-                <div class="grid-column-one-half">
-
-                </div>
-            </div>
-        </div>*@
     <div class="main-content">
         <div class="grid-row">
             <div class="grid-column-two-thirds">
@@ -72,7 +29,6 @@ else
                     </div>
 
                     <partial name="~/Views/Shared/Sidebar/_employer-without-navigation.cshtml" />
-
 
                 </div>
 


### PR DESCRIPTION
Updates the employer/apprentice caption to show the section, potential subsection and current page.

All pages will show the section (with a link back to the relevant real-stories page) and current page but a Subsection title and url can be passed to the heading view component on the page for pages that require it