### PR TITLE
AM-535 - Change to only use SharedRedis for data protection keys

### DIFF
--- a/src/SFA.DAS.Campaign.Infrastructure/Configuration/ConnectionStrings.cs
+++ b/src/SFA.DAS.Campaign.Infrastructure/Configuration/ConnectionStrings.cs
@@ -3,6 +3,5 @@
    public class ConnectionStrings
     {
         public string SharedRedis { get; set; }
-        public string ContentCacheDatabase { get; set; }
     }
 }

--- a/src/SFA.DAS.Campaign.Infrastructure/SFA.DAS.Campaign.Infrastructure.csproj
+++ b/src/SFA.DAS.Campaign.Infrastructure/SFA.DAS.Campaign.Infrastructure.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.1" />
-    <PackageReference Include="Polly" Version="6.1.0" />
+    <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="refit" Version="4.7.51" />
   </ItemGroup>
 

--- a/src/SFA.DAS.Campaign.Web/appsettings.json
+++ b/src/SFA.DAS.Campaign.Web/appsettings.json
@@ -33,7 +33,6 @@
   },
   "ConfigNames": "SFA.DAS.Campaign:CampaignConfiguration",
   "ConnectionStrings": {
-    "Redis": "localhost:6379",
     "SharedRedis": "localhost"
   },
   "VacanciesApi": {


### PR DESCRIPTION
Removed old redis cache that was used to get content before APIM implementation