### PR TITLE
QF-1273 Add the 'ForcePreview' variable to the das-campaigns config

### DIFF
--- a/src/SFA.DAS.Campaign.Application/Content/Queries/GetArticleQueryHandler.cs
+++ b/src/SFA.DAS.Campaign.Application/Content/Queries/GetArticleQueryHandler.cs
@@ -22,10 +22,11 @@ namespace SFA.DAS.Campaign.Application.Content.Queries
 
         public async Task<GetArticleQueryResult<Article>> Handle(GetArticleQuery request, CancellationToken cancellationToken)
         {
-            var canPreview = _config.Value.AllowPreview;
+            var allowPreview = _config.Value.AllowPreview;
+            var forcePreview = _config.Value.ForcePreview;
             Page<Article> article = null;
 
-            if (canPreview && request.Preview)
+            if (allowPreview && request.Preview || forcePreview)
             {
                 article = await _apiClient.Get<Page<Article>>(new GetArticlesPreviewRequest(request.Hub, request.Slug)).ConfigureAwait(false);
             }

--- a/src/SFA.DAS.Campaign.Application/Content/Queries/GetArticleQueryHandler.cs
+++ b/src/SFA.DAS.Campaign.Application/Content/Queries/GetArticleQueryHandler.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.Campaign.Application.Content.Queries
             var forcePreview = _config.Value.ForcePreview;
             Page<Article> article = null;
 
-            if (allowPreview && request.Preview || forcePreview)
+            if ((allowPreview && request.Preview) || forcePreview)
             {
                 article = await _apiClient.Get<Page<Article>>(new GetArticlesPreviewRequest(request.Hub, request.Slug)).ConfigureAwait(false);
             }

--- a/src/SFA.DAS.Campaign.Application/Content/Queries/GetHubQueryHandler.cs
+++ b/src/SFA.DAS.Campaign.Application/Content/Queries/GetHubQueryHandler.cs
@@ -22,10 +22,11 @@ namespace SFA.DAS.Campaign.Application.Content.Queries
 
         public async Task<GetHubQueryResult<Hub>> Handle(GetHubQuery request, CancellationToken cancellationToken)
         {
-            var canPreview = _config.Value.AllowPreview;
+            var allowPreview = _config.Value.AllowPreview;
+            var forcePreview = _config.Value.ForcePreview;
             Page<Hub> hub = null;
 
-            if (canPreview && request.Preview)
+            if (allowPreview && request.Preview || forcePreview)
             {
                 hub = await _apiClient.Get<Page<Hub>>(new GetHubPreviewRequest(request.Hub)).ConfigureAwait(false);
             }

--- a/src/SFA.DAS.Campaign.Application/Content/Queries/GetHubQueryHandler.cs
+++ b/src/SFA.DAS.Campaign.Application/Content/Queries/GetHubQueryHandler.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.Campaign.Application.Content.Queries
             var forcePreview = _config.Value.ForcePreview;
             Page<Hub> hub = null;
 
-            if (allowPreview && request.Preview || forcePreview)
+            if ((allowPreview && request.Preview) || forcePreview)
             {
                 hub = await _apiClient.Get<Page<Hub>>(new GetHubPreviewRequest(request.Hub)).ConfigureAwait(false);
             }

--- a/src/SFA.DAS.Campaign.Application/Content/Queries/GetLandingPageQueryHandler.cs
+++ b/src/SFA.DAS.Campaign.Application/Content/Queries/GetLandingPageQueryHandler.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.Campaign.Application.Content.Queries
             var forcePreview = _config.Value.ForcePreview;
             Page<LandingPage> landingPage = null;
 
-            if (allowPreview && request.Preview || forcePreview)
+            if ((allowPreview && request.Preview) || forcePreview)
             {
                 landingPage = await _apiClient.Get<Page<LandingPage>>(new GetLandingPagePreviewRequest(request.Hub, request.Slug)).ConfigureAwait(false);
             }

--- a/src/SFA.DAS.Campaign.Application/Content/Queries/GetLandingPageQueryHandler.cs
+++ b/src/SFA.DAS.Campaign.Application/Content/Queries/GetLandingPageQueryHandler.cs
@@ -22,10 +22,11 @@ namespace SFA.DAS.Campaign.Application.Content.Queries
 
         public async Task<GetLandingPageQueryResult<LandingPage>> Handle(GetLandingPageQuery request, CancellationToken cancellationToken)
         {
-            var canPreview = _config.Value.AllowPreview;
+            var allowPreview = _config.Value.AllowPreview;
+            var forcePreview = _config.Value.ForcePreview;
             Page<LandingPage> landingPage = null;
 
-            if (canPreview && request.Preview)
+            if (allowPreview && request.Preview || forcePreview)
             {
                 landingPage = await _apiClient.Get<Page<LandingPage>>(new GetLandingPagePreviewRequest(request.Hub, request.Slug)).ConfigureAwait(false);
             }

--- a/src/SFA.DAS.Campaign.Application/Content/Queries/GetPanelQueryHandler.cs
+++ b/src/SFA.DAS.Campaign.Application/Content/Queries/GetPanelQueryHandler.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.Campaign.Application.Content.Queries
             var forcePreview = _config.Value.ForcePreview;
             Panel panel = null;
 
-            if (allowPreview && request.Preview || forcePreview)
+            if ((allowPreview && request.Preview) || forcePreview)
             {
                 panel = await _apiClient.Get<Panel>(new GetPanelPreviewRequest(request.Id)).ConfigureAwait(false);
             }

--- a/src/SFA.DAS.Campaign.Application/Content/Queries/GetPanelQueryHandler.cs
+++ b/src/SFA.DAS.Campaign.Application/Content/Queries/GetPanelQueryHandler.cs
@@ -22,10 +22,11 @@ namespace SFA.DAS.Campaign.Application.Content.Queries
 
         public async Task<GetPanelQueryResult> Handle(GetPanelQuery request, CancellationToken cancellationToken)
         {
-            var canPreview = _config.Value.AllowPreview;
+            var allowPreview = _config.Value.AllowPreview;
+            var forcePreview = _config.Value.ForcePreview;
             Panel panel = null;
 
-            if (canPreview && request.Preview)
+            if (allowPreview && request.Preview || forcePreview)
             {
                 panel = await _apiClient.Get<Panel>(new GetPanelPreviewRequest(request.Id)).ConfigureAwait(false);
             }

--- a/src/SFA.DAS.Campaign.Infrastructure/Configuration/CampaignConfiguration.cs
+++ b/src/SFA.DAS.Campaign.Infrastructure/Configuration/CampaignConfiguration.cs
@@ -10,6 +10,7 @@ namespace SFA.DAS.Campaign.Infrastructure.Configuration
         public virtual OuterApiConfiguration OuterApi { get; set; }
         public virtual string EmployerAccountBaseUrl { get; set; }
         public bool AllowPreview { get;set; }
+        public bool ForcePreview { get; set; }
         public string BuildNumber { get ; set ; }
     }
 

--- a/src/SFA.DAS.Campaign.UnitTests/Infrastructure/Api/Queries/WhenGettingAnArticle.cs
+++ b/src/SFA.DAS.Campaign.UnitTests/Infrastructure/Api/Queries/WhenGettingAnArticle.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 using SFA.DAS.Campaign.Application.Content.Queries;
 using SFA.DAS.Campaign.Domain.Api.Interfaces;
 using SFA.DAS.Campaign.Domain.Content;
-using SFA.DAS.Campaign.Infrastructure.Api;
 using SFA.DAS.Campaign.Infrastructure.Api.Requests;
 using SFA.DAS.Campaign.Infrastructure.Configuration;
 using SFA.DAS.Testing.AutoFixture;
@@ -17,49 +16,111 @@ namespace SFA.DAS.Campaign.UnitTests.Infrastructure.Api.Queries
 {
     public class WhenGettingAnArticle
     {
-        [Test, RecursiveMoqAutoData]
-        public async Task Then_The_Api_Is_Called_With_The_Valid_Request_Parameters_And_The_Article_Is_Returned_From_The_Preview_Api_if_Config_And_Param_Set(
-            GetArticleQuery query, Page<Article> response, [Frozen] Mock<IOptions<CampaignConfiguration>> config, [Frozen] Mock<IApiClient> client, GetArticleQueryHandler handler)
+        [Test]
+        [MoqInlineAutoData(true, true)]
+        [MoqInlineAutoData(true, false)]
+        [MoqInlineAutoData(false, true)]
+        [MoqInlineAutoData(false, false)]
+        public async Task AndForcePreviewIsTrue_ThenTheArticleIsReturnedFromThePreviewAPI(
+            bool allowPreview, bool previewWanted, GetArticleQuery query, Page<Article> response, [Frozen] Mock<IOptions<CampaignConfiguration>> config, [Frozen] Mock<IApiClient> client, GetArticleQueryHandler handler)
         {
-            SetupMockConfig(config);
-            query.Preview = true;
+            query.Preview = previewWanted;
+            SetupMockConfig(config, allowPreview, true);
             client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesPreviewRequest>(r => r.GetUrl == $"article/preview/{query.Hub}/{query.Slug}"))).ReturnsAsync(response);
 
             var actual = await handler.Handle(query, CancellationToken.None);
 
-            client.Verify(o => o.Get<Page<Article>>(It.Is<GetArticlesPreviewRequest>(r => r.GetUrl == $"article/preview/{query.Hub}/{query.Slug}")), Times.Once);
-            actual.Should().NotBeNull();
-            actual.Page.Should().NotBeNull();
+            Assert.Multiple(() =>
+            {
+                client.Verify(o => o.Get<Page<Article>>(It.Is<GetArticlesPreviewRequest>(r => r.GetUrl == $"article/preview/{query.Hub}/{query.Slug}")), Times.Once);
+                actual.Should().NotBeNull();
+                actual.Page.Should().NotBeNull();
+            });
         }
 
-        [Test]
-        [RecursiveMoqInlineAutoData(true)]
-        [RecursiveMoqInlineAutoData(false)]
-        public async Task Then_The_Api_Is_Called_With_The_Valid_Request_Parameters_And_Preview_Is_Disabled_Then_The_Article_Is_Returned_From_The_Api(
-            bool preview, GetArticleQuery query, Page<Article> response, [Frozen] Mock<IApiClient> client, [Frozen] Mock<IOptions<CampaignConfiguration>> config, GetArticleQueryHandler handler)
+        [Test, MoqInlineAutoData(true, true)]
+        public async Task AndForcePreviewIsFalse_AndAllowPreviewIsTrue_AndPreviewIsWanted_ThenThePanelIsReturnedFromThePreviewAPI(
+           bool allowPreview, bool previewWanted, GetArticleQuery query, Page<Article> response, [Frozen] Mock<IOptions<CampaignConfiguration>> config, [Frozen] Mock<IApiClient> client, GetArticleQueryHandler handler)
         {
-            query.Preview = preview;
-            SetupMockConfig(config, false);
-            
+            query.Preview = previewWanted;
+            SetupMockConfig(config, allowPreview, false);
+            client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesPreviewRequest>(r => r.GetUrl == $"article/preview/{query.Hub}/{query.Slug}"))).ReturnsAsync(response);
+
+            var actual = await handler.Handle(query, CancellationToken.None);
+
+            Assert.Multiple(() =>
+            {
+                client.Verify(o => o.Get<Page<Article>>(It.Is<GetArticlesPreviewRequest>(r => r.GetUrl == $"article/preview/{query.Hub}/{query.Slug}")), Times.Once);
+                actual.Should().NotBeNull();
+                actual.Page.Should().NotBeNull();
+            });
+        }
+
+        [Test, MoqInlineAutoData(false, true)]
+        public async Task AndForcePreviewIsFalse_AndAllowPreviewIsFalse_AndPreviewIsWanted_ThenThePanelIsReturnedFromTheProductionAPI(
+            bool allowPreview, bool previewWanted, GetArticleQuery query, Page<Article> response, [Frozen] Mock<IOptions<CampaignConfiguration>> config, [Frozen] Mock<IApiClient> client, GetArticleQueryHandler handler)
+        {
+            query.Preview = previewWanted;
+            SetupMockConfig(config, allowPreview, false);
             client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}"))).ReturnsAsync(response);
 
             var actual = await handler.Handle(query, CancellationToken.None);
 
-            client.Verify(
-                o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}")), Times.Once);
-            client.Verify(o => o.Get<Page<Article>>(It.IsAny<GetArticlesPreviewRequest>()), Times.Never);
-            actual.Should().NotBeNull();
-            actual.Page.Should().NotBeNull();
+            Assert.Multiple(() =>
+            {
+                client.Verify(o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}")), Times.Once);
+                client.Verify(o => o.Get<Page<Article>>(It.IsAny<GetArticlesPreviewRequest>()), Times.Never);
+                actual.Should().NotBeNull();
+                actual.Page.Should().NotBeNull();
+            });
+        }
+
+        [Test, MoqInlineAutoData(true, false)]
+        public async Task AndForcePreviewIsFalse_AndAllowPreviewIsTrue_AndPreviewIsNotWanted_ThenThePanelIsReturnedFromTheProductionAPI(
+            bool allowPreview, bool previewWanted, GetArticleQuery query, Page<Article> response, [Frozen] Mock<IOptions<CampaignConfiguration>> config, [Frozen] Mock<IApiClient> client, GetArticleQueryHandler handler)
+        {
+            query.Preview = previewWanted;
+            SetupMockConfig(config, allowPreview, false);
+            client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}"))).ReturnsAsync(response);
+
+            var actual = await handler.Handle(query, CancellationToken.None);
+
+            Assert.Multiple(() =>
+            {
+                client.Verify(o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}")), Times.Once);
+                client.Verify(o => o.Get<Page<Article>>(It.IsAny<GetArticlesPreviewRequest>()), Times.Never);
+                actual.Should().NotBeNull();
+                actual.Page.Should().NotBeNull();
+            });
+        }
+
+        [Test, MoqInlineAutoData(false, false)]
+        public async Task AndForcePreviewIsFalse_AndAllowPreviewIsFalse_AndPreviewIsNotWanted_ThenThePanelIsReturnedFromTheProductionAPI(
+            bool allowPreview, bool previewWanted, GetArticleQuery query, Page<Article> response, [Frozen] Mock<IOptions<CampaignConfiguration>> config, [Frozen] Mock<IApiClient> client, GetArticleQueryHandler handler)
+        {
+            query.Preview = previewWanted;
+            SetupMockConfig(config, allowPreview, false);
+            client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}"))).ReturnsAsync(response);
+
+            var actual = await handler.Handle(query, CancellationToken.None);
+
+            Assert.Multiple(() =>
+            {
+                client.Verify(o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}")), Times.Once);
+                client.Verify(o => o.Get<Page<Article>>(It.IsAny<GetArticlesPreviewRequest>()), Times.Never);
+                actual.Should().NotBeNull();
+                actual.Page.Should().NotBeNull();
+            });
         }
 
         [Test]
-        [RecursiveMoqInlineAutoData(true)]
-        [RecursiveMoqInlineAutoData(false)]
-        public async Task Then_The_Api_Is_Called_With_The_Valid_Request_Parameters_Then_The_Article_Is_Returned_From_The_Api_With_The_Menu(
-            bool preview, GetArticleQuery query, Page<Article> response, [Frozen] Mock<IApiClient> client, [Frozen] Mock<IOptions<CampaignConfiguration>> config, GetArticleQueryHandler handler)
+        [RecursiveMoqInlineAutoData(true, false)]
+        [RecursiveMoqInlineAutoData(false, false)]
+        public async Task AndTheApiIsCalledWithTheValidRequestParameters_ThenTheArticleIsReturnedFromTheApiWithTheMenu(
+            bool previewWanted, bool allowPreview, GetArticleQuery query, Page<Article> response, [Frozen] Mock<IApiClient> client, [Frozen] Mock<IOptions<CampaignConfiguration>> config, GetArticleQueryHandler handler)
         {
-            query.Preview = preview;
-            SetupMockConfig(config, false);
+            query.Preview = previewWanted;
+            SetupMockConfig(config, allowPreview, false);
 
             client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}"))).ReturnsAsync(response);
 
@@ -80,10 +141,10 @@ namespace SFA.DAS.Campaign.UnitTests.Infrastructure.Api.Queries
         }
 
         [Test, RecursiveMoqAutoData]
-        public async Task And_The_Api_Is_Called_With_Invalid_Request_Parameters_Then_No_Article_Is_Returned(
+        public async Task AndTheApiIsCalledWithInvalidRequestParameters_ThenNoArticleIsReturned(
             GetArticleQuery query, [Frozen] Mock<IApiClient> client, [Frozen] Mock<IOptions<CampaignConfiguration>> config, GetArticleQueryHandler handler)
         {
-            SetupMockConfig(config);
+            SetupMockConfig(config, false, false);
             client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesPreviewRequest>(r => r.GetUrl == $"article/preview/{query.Hub}/{query.Slug}"))).ReturnsAsync((Page<Article>)null);
             client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}"))).ReturnsAsync((Page<Article>)null);
             client.Setup(o => o.Get<Page<Menu>>(It.Is<GetMenuRequest>(r => r.GetUrl == $"menu"))).ReturnsAsync((Page<Menu>)null);
@@ -95,10 +156,10 @@ namespace SFA.DAS.Campaign.UnitTests.Infrastructure.Api.Queries
         }
 
         [Test, RecursiveMoqAutoData]
-        public async Task And_The_Api_Is_Called_With_Invalid_Request_Parameters_For_Article_Page_Then_Landing_Page_Is_Returned(
+        public async Task AndTheApiIsCalledWithInvalidRequestParametersForArticlePage_ThenLandingPageIsReturned(
             GetLandingPageQuery query, Page<LandingPage> pageResponse, [Frozen] Mock<IApiClient> client, [Frozen] Mock<IOptions<CampaignConfiguration>> config, GetLandingPageQueryHandler landingPageHandler)
         {
-            SetupMockConfig(config);
+            SetupMockConfig(config, false, false);
             client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesPreviewRequest>(r => r.GetUrl == $"article/preview/{query.Hub}/{query.Slug}"))).ReturnsAsync((Page<Article>)null);
             client.Setup(o => o.Get<Page<Article>>(It.Is<GetArticlesRequest>(r => r.GetUrl == $"article/{query.Hub}/{query.Slug}"))).ReturnsAsync((Page<Article>)null);
 
@@ -111,9 +172,10 @@ namespace SFA.DAS.Campaign.UnitTests.Infrastructure.Api.Queries
             actual.Page.Should().NotBeNull();
         }
 
-        private static void SetupMockConfig(Mock<IOptions<CampaignConfiguration>> config, bool allowPreview = true)
+        private static void SetupMockConfig(Mock<IOptions<CampaignConfiguration>> config, bool allowPreview = true, bool forcePreview = false)
         {
             config.Object.Value.AllowPreview = allowPreview;
+            config.Object.Value.ForcePreview = forcePreview;
         }
     }
 }

--- a/src/SFA.DAS.Campaign.UnitTests/Infrastructure/Api/Queries/WhenGettingTheSiteMap.cs
+++ b/src/SFA.DAS.Campaign.UnitTests/Infrastructure/Api/Queries/WhenGettingTheSiteMap.cs
@@ -8,7 +8,6 @@ using NUnit.Framework;
 using SFA.DAS.Campaign.Application.Content.Queries;
 using SFA.DAS.Campaign.Domain.Api.Interfaces;
 using SFA.DAS.Campaign.Domain.Content;
-using SFA.DAS.Campaign.Infrastructure.Api;
 using SFA.DAS.Campaign.Infrastructure.Api.Requests;
 using SFA.DAS.Campaign.Infrastructure.Configuration;
 using SFA.DAS.Testing.AutoFixture;


### PR DESCRIPTION
Add the '`ForcePreview`' variable to the das-campaigns repository configuration to force the preview API to be used (_instead of the API for published content_). This variable will aid in testing, so that in TEST and similar environments when the tester submits a form and cannot alter the URL (as they could on a GET) to include the query string `'?preview=true'` the content will still be returned because the **preview API will automatically be used**. Previously when the tester was unable to alter the URL on a POST no content would be found.